### PR TITLE
sqauers => squares

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ These properties are only available for chess blocks.
 | **arrows**   | Series of arrows to draw                  | e2->e4 d2->d4        | Empty                               |
 | **squares**  | Series of squares to mark                 | e5 d5                | Empty                               |
 | **movable**  | Force to enable/disable movement          | true / false         | false if FEN supplied               |
-| **drawable** | Force to enable/disable drawing           | true / false         | false if arrows or sqaures supplied |
+| **drawable** | Force to enable/disable drawing           | true / false         | false if arrows or squares supplied |
 | **lastMove** | Highlight last move                       | e2 e4                | Undefined                           |
 | **moves**    | Sequence of moves to view in the position | e4 e5 Nf3 Nf6 Nxe5   | Undefined                           |
 | **variant**  | Variant name                              | Chess960             | Undefined                           |


### PR DESCRIPTION
Hello, I spotted a small typo: "sqaures" should be written as "squares".

Yours, Ari